### PR TITLE
Refactor/booking mechanism

### DIFF
--- a/internal/booking/controller/controller.go
+++ b/internal/booking/controller/controller.go
@@ -38,16 +38,6 @@ func (controller *BookingController) NewBooking(ctx *gin.Context) {
 		return
 	}
 
-	// The following process is proceed with assumptions the payment is success
-	// err = controller.querier.CreateBooking(ctx, bookingDetails)
-	// if err != nil {
-	// 	ctx.AbortWithStatusJSON(
-	// 		http.StatusInternalServerError,
-	// 		gin.H{"Err": err.Error()},
-	// 	)
-	// 	return
-	// }
-
 	ctx.JSON(
 		http.StatusAccepted,
 		gin.H{"Booking code": bookingDetails.BookingCode},

--- a/internal/exception/httpError.go
+++ b/internal/exception/httpError.go
@@ -33,6 +33,8 @@ func ParseError(err error) HttpError {
 		return NewHttpError(http.StatusBadRequest, "Bad Request", err)
 	case strings.Contains(strings.ToLower(err.Error()), "param"):
 		return NewHttpError(http.StatusBadRequest, "Invalid param", err)
+	case strings.Contains(strings.ToLower(err.Error()), "seat"):
+		return NewHttpError(http.StatusConflict, "Seat is Not Available", err)
 	default:
 		return NewHttpError(http.StatusInternalServerError, "Internal Server Error", err)
 	}

--- a/internal/seat/usecase/usecase.go
+++ b/internal/seat/usecase/usecase.go
@@ -32,26 +32,7 @@ func (uc *SeatUseCase) FindAvailableSeats(ctx context.Context, param model.Avail
 	}
 
 	if len(availableSeats) == 0 {
-		return nil, errors.New("no available seat")
-	}
-
-	// Check in redis for any existing booked seats
-	bookedSeats, err := uc.seatRedisRepo.GetBookedSeats(ctx, param.TravelId)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, bookedSeat := range bookedSeats {
-		// Overide the avaiability status
-		for wagonIdx, wagon := range availableSeats {
-			for rowIdx, row := range wagon.SeatingRows {
-				for seatIdx, seat := range row.RowElements {
-					if bookedSeat == seat.SeatId {
-						availableSeats[wagonIdx].SeatingRows[rowIdx].RowElements[seatIdx].Available = false
-					}
-				}
-			}
-		}
+		return nil, errors.New("no available travel.seats")
 	}
 
 	return availableSeats, nil


### PR DESCRIPTION
### Double Booking Prevention
To prevent the double booking, seats are being locked during booking process. When another user at the same time is trying to book the same seat, it will check the seat's lock in the redis first before proceeding the booking process.

### Seats selection
To find the available seats, it will only look for the seats from database. The redis checking is dropped to reduce the code complexity (It's not needed anymore)